### PR TITLE
New configuration options: prefix table names, and store executions or not

### DIFF
--- a/lib/generators/say_when/migration/migration_generator.rb
+++ b/lib/generators/say_when/migration/migration_generator.rb
@@ -14,8 +14,12 @@ module SayWhen
 
     argument :name, type: :string, default: 'random_name'
 
+    def prefix
+      SayWhen.options[:table_prefix] || ''
+    end
+
     def manifest
-      migration_template 'migration.rb', 'db/migrate/create_say_when_tables.rb'
+      migration_template('migration.rb', 'db/migrate/create_say_when_tables.rb')
     end
   end
 end

--- a/lib/generators/say_when/migration/templates/migration.rb
+++ b/lib/generators/say_when/migration/templates/migration.rb
@@ -4,7 +4,7 @@ class CreateSayWhenTables < ActiveRecord::Migration
 
   def self.up
 
-    create_table :say_when_jobs, :force => true do |t|
+    create_table :<%= prefix %>say_when_jobs, :force => true do |t|
       t.string    :group
       t.string    :name
 
@@ -29,10 +29,10 @@ class CreateSayWhenTables < ActiveRecord::Migration
       t.timestamps null: false
     end
 
-    add_index :say_when_jobs, [:next_fire_at, :status]
-    add_index :say_when_jobs, [:scheduled_type, :scheduled_id]
+    add_index :<%= prefix %>say_when_jobs, [:next_fire_at, :status]
+    add_index :<%= prefix %>say_when_jobs, [:scheduled_type, :scheduled_id]
 
-    create_table :say_when_job_executions, :force => true do |t|
+    create_table :<%= prefix %>say_when_job_executions, :force => true do |t|
       t.integer  :job_id
       t.string   :status
       t.text     :result
@@ -40,12 +40,12 @@ class CreateSayWhenTables < ActiveRecord::Migration
       t.datetime :end_at
     end
 
-    add_index :say_when_job_executions, :job_id
-    add_index :say_when_job_executions, [:status, :start_at, :end_at]
+    add_index :<%= prefix %>say_when_job_executions, :job_id
+    add_index :<%= prefix %>say_when_job_executions, [:status, :start_at, :end_at]
   end
 
   def self.down
-    drop_table :say_when_job_executions
-    drop_table :say_when_jobs
+    drop_table :<%= prefix %>say_when_job_executions
+    drop_table :<%= prefix %>say_when_jobs
   end
 end

--- a/lib/say_when/configuration.rb
+++ b/lib/say_when/configuration.rb
@@ -10,6 +10,8 @@ module SayWhen
         defaults[:tick_length] = (ENV['SAY_WHEN_TICK_LENGTH'] || '5').to_i
         defaults[:queue] = ENV['SAY_WHEN_QUEUE'] || 'default'
         defaults[:reset_acquired_length] = (ENV['SAY_WHEN_RESET_ACQUIRED_LENGTH'] || '3600').to_i
+        defaults[:store_executions] = false
+        defaults[:table_prefix] = ''
       end
     end
   end

--- a/lib/say_when/storage/active_record_strategy.rb
+++ b/lib/say_when/storage/active_record_strategy.rb
@@ -137,10 +137,10 @@ module SayWhen
           else
             begin
               result = self.execute_job(data)
-              SayWhen.logger.info("complete: #{result}")
+              SayWhen.logger.info("complete - job: #{self.inspect}, result: #{result}")
             rescue Object => ex
               result = "#{ex.class.name}: #{ex.message}\n\t#{ex.backtrace.join("\n\t")}"
-              SayWhen.logger.error("error: #{result}")
+              SayWhen.logger.error("error - job: #{self.inspect}, exception: #{result}")
             end
           end
           result

--- a/lib/say_when/storage/active_record_strategy.rb
+++ b/lib/say_when/storage/active_record_strategy.rb
@@ -137,9 +137,10 @@ module SayWhen
           else
             begin
               result = self.execute_job(data)
+              SayWhen.logger.info("complete: #{result}")
             rescue Object => ex
               result = "#{ex.class.name}: #{ex.message}\n\t#{ex.backtrace.join("\n\t")}"
-              SayWhen.logger.error(result)
+              SayWhen.logger.error("error: #{result}")
             end
           end
           result

--- a/test/db/schema.rb
+++ b/test/db/schema.rb
@@ -2,7 +2,7 @@
 
 ActiveRecord::Schema.define(:version => 0) do
 
-  create_table :say_when_jobs, :force => true do |t|
+  create_table :test_say_when_jobs, :force => true do |t|
 
     t.string    :status
 
@@ -23,7 +23,7 @@ ActiveRecord::Schema.define(:version => 0) do
     t.timestamps null: false
   end
 
-  create_table :say_when_job_executions, :force => true do |t|
+  create_table :test_say_when_job_executions, :force => true do |t|
     t.integer  :job_id
     t.string   :status
     t.text     :result
@@ -31,8 +31,8 @@ ActiveRecord::Schema.define(:version => 0) do
     t.datetime :end_at
   end
 
-  add_index :say_when_jobs, :status
-  add_index :say_when_jobs, :next_fire_at
+  add_index :test_say_when_jobs, :status
+  add_index :test_say_when_jobs, :next_fire_at
 
 
 end

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -31,6 +31,7 @@ Celluloid.boot
 SayWhen.configure do |options|
   options[:storage_strategy]   = :memory
   options[:processor_strategy] = :test
+  options[:table_prefix] = 'test_'
 end
 
 SayWhen.logger = Logger.new('/dev/null')


### PR DESCRIPTION
- [x] Provide a prefix for table names that will be used in both migration generation and models
- [x] Opt out of storing execution results in the db, will log results and errors