### PR TITLE
Make compatible with Ruby 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,11 @@ source "http://rubygems.org"
 
 # Specify your gem's dependencies in say_when.gemspec
 gemspec
+
+gem "rspec", "=1.3.2", git: 'https://github.com/makandra/rspec.git', branch: '1-3-lts'
+
+git 'https://github.com/makandra/rails.git', :branch => '2-3-lts' do
+  gem 'rails', '~>2.3.18'
+  gem 'activesupport',    :require => false
+  gem 'railslts-version', :require => false
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,9 @@
 require "bundler/gem_tasks"
+require 'spec/rake/spectask'
+
+desc "Run all tests"
+Spec::Rake::SpecTask.new('test') do |t|
+  t.spec_files = FileList['spec/**/*_spec.rb']
+end
+
+task :default => :test

--- a/lib/say_when/version.rb
+++ b/lib/say_when/version.rb
@@ -1,3 +1,3 @@
 module SayWhen
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/say_when.gemspec
+++ b/say_when.gemspec
@@ -18,8 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "activemessaging", '~> 0.9.0'
   s.add_development_dependency "activesupport", '~> 2.3.14'
   s.add_development_dependency "activerecord", '~> 2.3.14'
-  s.add_development_dependency 'rspec', "~> 1.3"
+  s.add_development_dependency 'rspec', '~> 1.3'
+  s.add_development_dependency 'rake', '~> 10.5.0'
   s.add_development_dependency 'sqlite3'
-  s.add_development_dependency 'rake', '~> 0.8.7'
-
 end

--- a/spec/active_record_spec_helper.rb
+++ b/spec/active_record_spec_helper.rb
@@ -1,8 +1,6 @@
 require 'active_record'
 require 'sqlite3'
 
-ActiveRecord::Base.logger = Logger.new(STDOUT)
-
 ActiveRecord::Base.establish_connection(
   :adapter => "sqlite3",
   :database  => (File.dirname(__FILE__) + "/db/test.db")

--- a/spec/say_when/cron_expression_spec.rb
+++ b/spec/say_when/cron_expression_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require_relative '../spec_helper'
 
 describe SayWhen::CronExpression do
 

--- a/spec/say_when/processor/active_messaging_spec.rb
+++ b/spec/say_when/processor/active_messaging_spec.rb
@@ -1,7 +1,6 @@
-
-require File.dirname(__FILE__) + '/../../spec_helper'
-require File.dirname(__FILE__) + '/../../../lib/say_when/processor/active_messaging'
-require File.dirname(__FILE__) + '/../../../lib/say_when/storage/active_record/job'
+require_relative '../../spec_helper'
+require_relative '../../../lib/say_when/processor/active_messaging'
+require_relative '../../../lib/say_when/storage/active_record/job'
 
 def destination(destination_name)
   d = ActiveMessaging::Gateway.find_destination(destination_name).value

--- a/spec/say_when/scheduler_spec.rb
+++ b/spec/say_when/scheduler_spec.rb
@@ -1,5 +1,5 @@
-require File.dirname(__FILE__) + '/../spec_helper'
-require File.dirname(__FILE__) + '/../active_record_spec_helper'
+require_relative '../spec_helper'
+require_relative '../active_record_spec_helper'
 
 describe SayWhen::Scheduler do
 
@@ -58,15 +58,15 @@ describe SayWhen::Scheduler do
     it "should start the scheduler running and stop it" do
       @scheduler.running.should be_false
 
-      puts 'starting'
+      # puts 'starting'
       scheduler_thread = Thread.start{@scheduler.start}
-      puts 'started'
+      # puts 'started'
       sleep(0.1)
       @scheduler.running.should == true
 
-      puts 'stop'
+      # puts 'stop'
       @scheduler.stop
-      puts 'wait for it'
+      # puts 'wait for it'
       @scheduler.running.should == false
     end
 

--- a/spec/say_when/storage/active_record/job_spec.rb
+++ b/spec/say_when/storage/active_record/job_spec.rb
@@ -1,6 +1,6 @@
-require File.dirname(__FILE__) + '/../../../spec_helper'
-require File.dirname(__FILE__) + '/../../../active_record_spec_helper'
-require File.dirname(__FILE__) + '/../../../../lib/say_when/storage/active_record/job'
+require_relative '../../../spec_helper'
+require_relative '../../../active_record_spec_helper'
+require_relative '../../../../lib/say_when/storage/active_record/job'
 
 describe SayWhen::Storage::ActiveRecord::Job do
 
@@ -66,14 +66,15 @@ describe SayWhen::Storage::ActiveRecord::Job do
     j2_opts = {
       :trigger_strategy => :cron,
       :trigger_options  => {:expression => '0 0 10 ? * * *', :time_zone  => 'Pacific Time (US & Canada)'},
-      :data             => {:foo=>'bar', :result=>2},
+      :data             => {:foo=>'can find the next job - j2', :result=>2},
       :job_class        => 'SayWhen::Test::TestTask',
       :job_method       => 'execute'
     }
 
     j1 = SayWhen::Storage::ActiveRecord::Job.create(@valid_attributes)
     j2 = SayWhen::Storage::ActiveRecord::Job.create(j2_opts)
-    next_job = SayWhen::Storage::ActiveRecord::Job.acquire_next(1.day.since)
+    acquire = 1.day.since
+    next_job = SayWhen::Storage::ActiveRecord::Job.acquire_next(acquire)
     next_job.should == j2
   end
 
@@ -94,5 +95,4 @@ describe SayWhen::Storage::ActiveRecord::Job do
     j.last_fire_at.should == now
     j.status.should == SayWhen::BaseJob::STATE_WAITING
   end
-
 end

--- a/spec/say_when/storage/memory/job_spec.rb
+++ b/spec/say_when/storage/memory/job_spec.rb
@@ -1,5 +1,5 @@
-require File.dirname(__FILE__) + '/../../../spec_helper'
-require File.dirname(__FILE__) + '/../../../../lib/say_when/storage/memory/job'
+require_relative '../../../spec_helper'
+require_relative '../../../../lib/say_when/storage/memory/job'
 
 describe SayWhen::Store::Memory::Job do
 

--- a/spec/say_when/storage/memory/trigger_spec.rb
+++ b/spec/say_when/storage/memory/trigger_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../../spec_helper'
+require_relative '../../../spec_helper'
 # require File.dirname(__FILE__) + '/../../../../lib/say_when/store/memory/trigger'
 
 # describe SayWhen::Store::Memory::Trigger do

--- a/spec/say_when/triggers/once_strategy_spec.rb
+++ b/spec/say_when/triggers/once_strategy_spec.rb
@@ -1,5 +1,5 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
-require File.dirname(__FILE__) + '/../../../lib/say_when/triggers/once_strategy'
+require_relative '../../spec_helper'
+require_relative '../../../lib/say_when/triggers/once_strategy'
 
 describe SayWhen::Triggers::OnceStrategy do
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ ENV['RAILS_ENV']='test'
 require "rubygems"
 require 'bundler/setup'
 require 'active_support'
+require 'active_record'
 
 require 'spec'
 require 'spec/autorun'
@@ -10,7 +11,13 @@ require 'spec/autorun'
 $: << (File.dirname(__FILE__) + "/../lib")
 require "say_when"
 
+logger = Logger.new(STDOUT)
+logger.level = Logger::ERROR
+SayWhen.logger = logger
+::ActiveRecord::Base.logger = logger
+
 Dir[File.expand_path(File.join(File.dirname(__FILE__),'support','**','*.rb'))].each {|f| require f}
+
 
 Spec::Runner.configure do |config|
   config.mock_with :rspec


### PR DESCRIPTION
The 0.3.0 version works with Rails 2 and older Ruby.
This new 0.4.0 version works with the latest Rails LTS 2.3 and Ruby 2.7

The main changes here are to:
* Refactor the scheduler to allow the job handling to be called outside its own process management
* Get the specs working, and with a default rake task to run them

