### PR TITLE
Rails 7 updates

### DIFF
--- a/lib/say_when/poller/concurrent_poller.rb
+++ b/lib/say_when/poller/concurrent_poller.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'concurrent'
 require 'logger'
 require 'say_when/poller/base_poller'
@@ -11,20 +9,19 @@ module SayWhen
 
       def initialize(tick = nil)
         @tick_length = tick.to_i if tick
-        start
       end
 
       def start
-        @tick_timer = Concurrent::TimerTask.new(execution_interval: tick_length) do
+        @tick_timer ||= Concurrent::TimerTask.new(execution_interval: tick_length) do
           process_jobs
         end.tap(&:execute)
       end
 
       def stop
-        if @tick_timer
-          @tick_timer.shutdown
-          @tick_timer = nil
-        end
+        return unless @tick_timer
+
+        @tick_timer.shutdown
+        @tick_timer = nil
       end
     end
   end

--- a/lib/say_when/version.rb
+++ b/lib/say_when/version.rb
@@ -1,5 +1,5 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 module SayWhen
-  VERSION = '2.1.1'
+  VERSION = '2.2.0'
 end

--- a/test/say_when/storage/active_record_strategy_test.rb
+++ b/test/say_when/storage/active_record_strategy_test.rb
@@ -85,7 +85,7 @@ describe SayWhen::Storage::ActiveRecordStrategy do
   it 'resets acquired jobs' do
     old = 2.hours.ago
     j = strategy.create(valid_attributes)
-    j.update_attributes(status: 'acquired', updated_at: old, created_at: old)
+    j.update(status: 'acquired', updated_at: old, created_at: old)
 
     j.status.must_equal 'acquired'
 


### PR DESCRIPTION
- `update_attrbutes` -> `update`
- Change suppress logging logic to prevent errors
- Clean up Arel queries to use less string args
- In `ConcurrentPoller`, don't start on create, let that happen in app's control